### PR TITLE
Remove opinionated rerun on changes to dir

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,10 +50,6 @@ pub fn init() {
 }
 
 fn __init(w: &mut impl std::io::Write) -> std::io::Result<()> {
-    // Require the build script to rerun if anything in the directory changes,
-    // since anything changing could affect the git revision.
-    writeln!(w, "cargo:rerun-if-changed=.")?;
-
     let mut git_sha: Option<String> = None;
 
     // Read the git revision from the JSON file embedded by cargo publish. This

--- a/src/test.rs
+++ b/src/test.rs
@@ -10,10 +10,9 @@ fn test_init() {
     assert!(res.is_ok());
     let out = str::from_utf8(&out).unwrap();
     println!("{out}");
-    assert!(Regex::new(
-        "cargo:rerun-if-changed=.
-cargo:rustc-env=GIT_REVISION=[0-9a-f]+(-dirty)?"
-    )
-    .unwrap()
-    .is_match(out));
+    assert!(
+        Regex::new("cargo:rustc-env=GIT_REVISION=[0-9a-f]+(-dirty)?")
+            .unwrap()
+            .is_match(out)
+    );
 }


### PR DESCRIPTION
### What
Remove the rerun on changes to anything in the current directory that is included in the build.rs init function..

### Why
It is too opinionated. Importers should be in full control of when rerun occurs. And anyway, by default the default rerun configuration of cargo will rerun on any changes to the crate so the rerun on changes to `.` is unnecessary in most cases.

A downside of including `.` is that it includes the `target/` folder, which changes on every build, meaning that the build.rs will always be rebuilt and rerun.

Fix #4