### PR TITLE
Rerun build script if some .git files change

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,21 @@ fn __init(w: &mut impl std::io::Write) -> std::io::Result<()> {
     // Read the git revision from the git repository containing the code being
     // built.
     if git_sha.is_none() {
+        // Require the build script to rerun if relavent git state changes which
+        // changes the current git commit.
+        //  - .git/index: Changes if the index/staged files changes, which will
+        //  cause the repo to be dirty.
+        //  - .git/HEAD: Changes if the ref currently in the working directory,
+        //  and potentially the commit, to change.
+        //  - .git/refs: Changes to any files in refs could cause the current
+        //  commit to have changed if the ref in .git/HEAD is changed.
+        // Note: That changes in the above files may not result in material
+        // changes to the crate, but changes in any should invalidate the
+        // revision since the revision can be changed by any of the above.
+        writeln!(w, "cargo:rerun-if-changed=.git/index")?;
+        writeln!(w, "cargo:rerun-if-changed=.git/HEAD")?;
+        writeln!(w, "cargo:rerun-if-changed=.git/refs")?;
+
         if let Ok(git_describe) = Command::new("git")
             .arg("describe")
             .arg("--always")

--- a/src/test.rs
+++ b/src/test.rs
@@ -10,9 +10,12 @@ fn test_init() {
     assert!(res.is_ok());
     let out = str::from_utf8(&out).unwrap();
     println!("{out}");
-    assert!(
-        Regex::new("cargo:rustc-env=GIT_REVISION=[0-9a-f]+(-dirty)?")
-            .unwrap()
-            .is_match(out)
-    );
+    assert!(Regex::new(
+        "cargo:rerun-if-changed=.git/index
+cargo:rerun-if-changed=.git/HEAD
+cargo:rerun-if-changed=.git/refs
+cargo:rustc-env=GIT_REVISION=[0-9a-f]+(-dirty)?"
+    )
+    .unwrap()
+    .is_match(out));
 }


### PR DESCRIPTION
### What
Rerun build script if some .git files change, when the version was prior set from git information.

### Why
If the .git files referenced in this change, change, then that is an indication that the current git revision may have changed, or that the working directory is now dirty.

Fix #4