### PR TITLE
Find the git directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "crate-git-revision"
 version = "0.0.3"
 dependencies = [
@@ -19,6 +31,25 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "tempfile",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -26,6 +57,12 @@ name = "itoa"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+
+[[package]]
+name = "libc"
+version = "0.2.138"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
 
 [[package]]
 name = "memchr"
@@ -52,6 +89,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,6 +113,15 @@ name = "regex-syntax"
 version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "ryu"
@@ -114,7 +169,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ serde_json = "1.0.82"
 
 [dev_dependencies]
 regex = "1.6.0"
+tempfile = "3.3.0"

--- a/src/test.rs
+++ b/src/test.rs
@@ -18,7 +18,7 @@ fn init_git_repo(path: &Path) {
         .current_dir(&path)
         .arg("config")
         .arg("user.email")
-        .arg("whatever@whatever.com")
+        .arg("whatever@example.com")
         .output()
         .unwrap();
     assert!(output.status.success());

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,21 +1,127 @@
 #![cfg(test)]
 
 use regex::Regex;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
 use std::str;
+
+fn init_git_repo(path: &Path) {
+    Command::new("git")
+        .current_dir(&path)
+        .arg("init")
+        .output()
+        .unwrap();
+
+    let file = path.join("readme");
+    fs::write(&file, "hello").unwrap();
+
+    Command::new("git")
+        .current_dir(&path)
+        .arg("add")
+        .arg("readme")
+        .output()
+        .unwrap();
+
+    Command::new("git")
+        .current_dir(&path)
+        .arg("commit")
+        .arg("-am")
+        .arg("test")
+        .output()
+        .unwrap();
+}
 
 #[test]
 fn test_init() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let git_dir = tempdir.path();
+
+    init_git_repo(&git_dir);
+
     let mut out = Vec::new();
-    let res = super::__init(&mut out);
+    let res = super::__init(&mut out, &git_dir);
     assert!(res.is_ok());
     let out = str::from_utf8(&out).unwrap();
-    println!("{out}");
-    assert!(Regex::new(
-        "cargo:rerun-if-changed=.git/index
+    let expected = "cargo:rerun-if-changed=.git/index
 cargo:rerun-if-changed=.git/HEAD
 cargo:rerun-if-changed=.git/refs
-cargo:rustc-env=GIT_REVISION=[0-9a-f]+(-dirty)?"
-    )
-    .unwrap()
-    .is_match(out));
+cargo:rustc-env=GIT_REVISION=[0-9a-f]+";
+    println!("{out}");
+    println!("{expected}");
+    assert!(Regex::new(expected).unwrap().is_match(out));
+}
+
+#[test]
+fn test_init_subdir() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let git_dir = tempdir.path();
+
+    init_git_repo(&git_dir);
+
+    let manifest_dir = git_dir.join("subdir");
+    std::fs::create_dir(&manifest_dir).unwrap();
+
+    let mut out = Vec::new();
+    let res = super::__init(&mut out, &manifest_dir);
+    assert!(res.is_ok());
+    let out = str::from_utf8(&out).unwrap();
+    let expected = &format!(
+        "cargo:rerun-if-changed={gd}/.git/index
+cargo:rerun-if-changed={gd}/.git/HEAD
+cargo:rerun-if-changed={gd}/.git/refs
+cargo:rustc-env=GIT_REVISION=[0-9a-f]+",
+        gd = git_dir.display()
+    );
+    println!("{out}");
+    println!("{expected}");
+    assert!(Regex::new(expected).unwrap().is_match(out));
+}
+
+#[test]
+fn test_dirty() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let git_dir = tempdir.path();
+
+    init_git_repo(&git_dir);
+
+    let file = git_dir.join("readme");
+    fs::write(&file, "dirty").unwrap();
+
+    let mut out = Vec::new();
+    let res = super::__init(&mut out, &git_dir);
+    assert!(res.is_ok());
+    let out = str::from_utf8(&out).unwrap();
+    let expected = "cargo:rerun-if-changed=.git/index
+cargo:rerun-if-changed=.git/HEAD
+cargo:rerun-if-changed=.git/refs
+cargo:rustc-env=GIT_REVISION=[0-9a-f]+-dirty";
+    println!("{out}");
+    println!("{expected}");
+    assert!(Regex::new(expected).unwrap().is_match(out));
+}
+
+#[test]
+fn test_published() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let crate_dir = tempdir.path();
+
+    let vcs_info = r#"{
+  "git": {
+    "sha1": "0c5255b6f47649305fcb68edccb285510aec71a7"
+  },
+  "path_in_vcs": ""
+}"#;
+
+    let file = crate_dir.join(".cargo_vcs_info.json");
+    fs::write(&file, vcs_info).unwrap();
+
+    let mut out = Vec::new();
+    let res = super::__init(&mut out, &crate_dir);
+    assert!(res.is_ok());
+    let out = str::from_utf8(&out).unwrap();
+    let expected = "cargo:rustc-env=GIT_REVISION=0c5255b6f47649305fcb68edccb285510aec71a7\n";
+    println!("{out}");
+    println!("{expected}");
+    assert_eq!(out, expected);
 }


### PR DESCRIPTION
Previously https://github.com/stellar/crate-git-revision/pull/8, which I closed on accident, and can't be reopened because I force-pushed.

In this revision I updated the test cases to set the user name / email in the test git repos, and used `std::fs::canonicalize` to resolve symlinks in the subdir case. I tested that these work on CI on my on fork. I think I tested the mac case on CI too, but am not sure.

### What

This adds a search for the `.git` directory.

### Why

I am seeing consistent rebuilds of `soroban-env-common` when building `soroban-examples`. This crate is located in a subdirectory of its git repo, and the emitted `rerun-if-change` messages are seemingly incorrect.

I have tested that this patch both triggers a rebuild correctly, and does not trigger a rebuild correctly in a few scenarios.

### Known limitations

N/A
