### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,9 +85,9 @@ fn __init(w: &mut impl std::io::Write, current_dir: &Path) -> std::io::Result<()
             // Note: That changes in the above files may not result in material
             // changes to the crate, but changes in any should invalidate the
             // revision since the revision can be changed by any of the above.
-            writeln!(w, "cargo:rerun-if-changed={}/index", git_dir)?;
-            writeln!(w, "cargo:rerun-if-changed={}/HEAD", git_dir)?;
-            writeln!(w, "cargo:rerun-if-changed={}/refs", git_dir)?;
+            writeln!(w, "cargo:rerun-if-changed={git_dir}/index")?;
+            writeln!(w, "cargo:rerun-if-changed={git_dir}/HEAD")?;
+            writeln!(w, "cargo:rerun-if-changed={git_dir}/refs")?;
 
             if let Ok(git_describe) = Command::new("git")
                 .current_dir(current_dir)

--- a/src/test.rs
+++ b/src/test.rs
@@ -8,14 +8,14 @@ use std::str;
 
 fn init_git_repo(path: &Path) {
     let output = Command::new("git")
-        .current_dir(&path)
+        .current_dir(path)
         .arg("init")
         .output()
         .unwrap();
     assert!(output.status.success());
 
     let output = Command::new("git")
-        .current_dir(&path)
+        .current_dir(path)
         .arg("config")
         .arg("user.email")
         .arg("whatever@example.com")
@@ -24,7 +24,7 @@ fn init_git_repo(path: &Path) {
     assert!(output.status.success());
 
     let output = Command::new("git")
-        .current_dir(&path)
+        .current_dir(path)
         .arg("config")
         .arg("user.name")
         .arg("whatever")
@@ -33,10 +33,10 @@ fn init_git_repo(path: &Path) {
     assert!(output.status.success());
 
     let file = path.join("readme");
-    fs::write(&file, "hello").unwrap();
+    fs::write(file, "hello").unwrap();
 
     let output = Command::new("git")
-        .current_dir(&path)
+        .current_dir(path)
         .arg("add")
         .arg("readme")
         .output()
@@ -44,7 +44,7 @@ fn init_git_repo(path: &Path) {
     assert!(output.status.success());
 
     let output = Command::new("git")
-        .current_dir(&path)
+        .current_dir(path)
         .arg("commit")
         .arg("-am")
         .arg("test")
@@ -58,10 +58,10 @@ fn test_init() {
     let tempdir = tempfile::tempdir().unwrap();
     let git_dir = tempdir.path();
 
-    init_git_repo(&git_dir);
+    init_git_repo(git_dir);
 
     let mut out = Vec::new();
-    let res = super::__init(&mut out, &git_dir);
+    let res = super::__init(&mut out, git_dir);
     assert!(res.is_ok());
     let out = str::from_utf8(&out).unwrap();
     let expected = "cargo:rerun-if-changed=.git/index
@@ -78,7 +78,7 @@ fn test_init_subdir() {
     let tempdir = tempfile::tempdir().unwrap();
     let git_dir = tempdir.path();
 
-    init_git_repo(&git_dir);
+    init_git_repo(git_dir);
 
     let manifest_dir = git_dir.join("subdir");
     std::fs::create_dir(&manifest_dir).unwrap();
@@ -110,13 +110,13 @@ fn test_dirty() {
     let tempdir = tempfile::tempdir().unwrap();
     let git_dir = tempdir.path();
 
-    init_git_repo(&git_dir);
+    init_git_repo(git_dir);
 
     let file = git_dir.join("readme");
-    fs::write(&file, "dirty").unwrap();
+    fs::write(file, "dirty").unwrap();
 
     let mut out = Vec::new();
-    let res = super::__init(&mut out, &git_dir);
+    let res = super::__init(&mut out, git_dir);
     assert!(res.is_ok());
     let out = str::from_utf8(&out).unwrap();
     let expected = "cargo:rerun-if-changed=.git/index
@@ -141,10 +141,10 @@ fn test_published() {
 }"#;
 
     let file = crate_dir.join(".cargo_vcs_info.json");
-    fs::write(&file, vcs_info).unwrap();
+    fs::write(file, vcs_info).unwrap();
 
     let mut out = Vec::new();
-    let res = super::__init(&mut out, &crate_dir);
+    let res = super::__init(&mut out, crate_dir);
     assert!(res.is_ok());
     let out = str::from_utf8(&out).unwrap();
     let expected = "cargo:rustc-env=GIT_REVISION=0c5255b6f47649305fcb68edccb285510aec71a7\n";


### PR DESCRIPTION
### What
Remove borrows of some variables.

Move println inputs into string.

### Why
The borrows are unnecessary.

Clippy prefers the vars inlined into the format string.