### PR TITLE
Skip empty git sha

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,10 @@ fn __init(w: &mut impl std::io::Write, current_dir: &Path) -> std::io::Result<()
     }
 
     if let Some(git_sha) = git_sha {
-        writeln!(w, "cargo:rustc-env=GIT_REVISION={git_sha}")?;
+        let git_sha = git_sha.trim_end();
+        if !git_sha.is_empty() {
+            writeln!(w, "cargo:rustc-env=GIT_REVISION={git_sha}")?;
+        }
     }
 
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ fn __init(w: &mut impl std::io::Write, current_dir: &Path) -> std::io::Result<()
     if let Ok(vcs_info) = read_to_string(current_dir.join(".cargo_vcs_info.json")) {
         let vcs_info: Result<CargoVcsInfo, _> = serde_json::from_str(&vcs_info);
         if let Ok(vcs_info) = vcs_info {
-            git_sha = Some(vcs_info.git.sha1);
+            git_sha = Some(vcs_info.git.sha1.trim().to_string());
         }
     }
 
@@ -157,11 +157,8 @@ fn __init(w: &mut impl std::io::Write, current_dir: &Path) -> std::io::Result<()
         }
     }
 
-    if let Some(git_sha) = git_sha {
-        let git_sha = git_sha.trim_end();
-        if !git_sha.is_empty() {
-            writeln!(w, "cargo:rustc-env=GIT_REVISION={git_sha}")?;
-        }
+    if let Some(git_sha) = git_sha.filter(|s| !s.is_empty()) {
+        writeln!(w, "cargo:rustc-env=GIT_REVISION={git_sha}")?;
     }
 
     Ok(())

--- a/src/test.rs
+++ b/src/test.rs
@@ -218,3 +218,53 @@ fn test_published() {
     println!("{expected}");
     assert_eq!(out, expected);
 }
+
+#[test]
+fn test_published_empty_sha() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let crate_dir = tempdir.path();
+
+    let vcs_info = r#"{
+  "git": {
+    "sha1": ""
+  },
+  "path_in_vcs": ""
+}"#;
+
+    let file = crate_dir.join(".cargo_vcs_info.json");
+    fs::write(file, vcs_info).unwrap();
+
+    let mut out = Vec::new();
+    let res = super::__init(&mut out, crate_dir);
+    assert!(res.is_ok());
+    let out = str::from_utf8(&out).unwrap();
+    let expected = "";
+    println!("{out}");
+    println!("{expected}");
+    assert_eq!(out, expected);
+}
+
+#[test]
+fn test_published_trailing_whitespace() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let crate_dir = tempdir.path();
+
+    let vcs_info = r#"{
+  "git": {
+    "sha1": "0c5255b6f47649305fcb68edccb285510aec71a7 \r\n\t\n"
+  },
+  "path_in_vcs": ""
+}"#;
+
+    let file = crate_dir.join(".cargo_vcs_info.json");
+    fs::write(file, vcs_info).unwrap();
+
+    let mut out = Vec::new();
+    let res = super::__init(&mut out, crate_dir);
+    assert!(res.is_ok());
+    let out = str::from_utf8(&out).unwrap();
+    let expected = "cargo:rustc-env=GIT_REVISION=0c5255b6f47649305fcb68edccb285510aec71a7\n";
+    println!("{out}");
+    println!("{expected}");
+    assert_eq!(out, expected);
+}


### PR DESCRIPTION
### What

- Trim whitespace from the `sha1` read out of `.cargo_vcs_info.json`,
  mirroring the trim already applied to `git rev-parse HEAD` output.
- Skip emitting `GIT_REVISION` when the resolved sha is empty —
  matching the existing behavior for the `None` case.

### Why

A malformed or empty `sha1` field in `.cargo_vcs_info.json` would
previously be passed through verbatim to `cargo:rustc-env=GIT_REVISION=`,
producing a build that compiles but exposes a bogus revision string (or
one that includes stray whitespace). Treating an empty sha the same as a
missing one keeps the contract consistent: either `GIT_REVISION` reflects
a real revision, or it isn't set. Applications can choose what to do with
a missing `GIT_REVISION` and only have to handle that one case instead of
two cases `None` or empty.