### PR TITLE
Mark dirty when git status exits non-zero

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,9 +138,16 @@ fn __init(w: &mut impl std::io::Write, current_dir: &Path) -> std::io::Result<()
                                 .arg("--porcelain")
                                 .arg("--untracked-files=normal")
                                 .output()
-                                .map(|o| o.stdout)
                             {
-                                Ok(status) => !status.is_empty(),
+                                Ok(output) if output.status.success() => !output.stdout.is_empty(),
+                                Ok(output) => {
+                                    writeln!(
+                                        w,
+                                        "cargo:warning=Error checking git dirty status from {current_dir:?}, marking as dirty: git status exited with {status}",
+                                        status = output.status,
+                                    )?;
+                                    true
+                                }
                                 Err(e) => {
                                     writeln!(
                                         w,

--- a/src/test.rs
+++ b/src/test.rs
@@ -152,6 +152,31 @@ cargo:rustc-env=GIT_REVISION=[0-9a-f]{40}-dirty\n";
 }
 
 #[test]
+fn test_dirty_when_status_fails() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let git_dir = tempdir.path();
+
+    init_git_repo(git_dir);
+
+    // Corrupt the index so `git status` fails with a non-zero exit but
+    // `git rev-parse HEAD` still succeeds.
+    fs::write(git_dir.join(".git/index"), "garbage").unwrap();
+
+    let mut out = Vec::new();
+    let res = super::__init(&mut out, git_dir);
+    assert!(res.is_ok());
+    let out = str::from_utf8(&out).unwrap();
+    let expected = "cargo:rerun-if-changed=.git/index
+cargo:rerun-if-changed=.git/HEAD
+cargo:rerun-if-changed=.git/refs
+cargo:warning=Error checking git dirty status from .*, marking as dirty: .*
+cargo:rustc-env=GIT_REVISION=[0-9a-f]{40}-dirty\n";
+    println!("{out}");
+    println!("{expected}");
+    assert!(Regex::new(expected).unwrap().is_match(out));
+}
+
+#[test]
 fn test_init_with_tag_does_not_use_describe() {
     let tempdir = tempfile::tempdir().unwrap();
     let git_dir = tempdir.path();


### PR DESCRIPTION
### What
Check `status.success()` on the `git status --porcelain` output before
trusting its stdout. When `git status` exits with a non-zero status,
emit a `cargo:warning` and mark the revision as `-dirty` rather than
silently treating an empty stdout as a clean tree.

Adds `test_dirty_when_status_fails`, which corrupts `.git/index` so
that `git rev-parse HEAD` still succeeds but `git status` fails with
exit 128, and asserts the emitted `GIT_REVISION` carries the `-dirty`
suffix.

### Why
`Command::output()` returns `Ok` even when the child process exits
non-zero. In that case stdout is usually empty, so the previous match
arm `Ok(status) => !status.is_empty()` mapped a failing `git status`
to a clean tree and stamped a bare SHA into `GIT_REVISION` — the
exact reproducibility hole #24 and #26 were meant to close.

Raised in review
[#26](https://github.com/stellar/crate-git-revision/pull/26#discussion_r3175821566).