### PR TITLE
Insulate git invocations from env and config

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,36 +161,20 @@ fn __init(w: &mut impl std::io::Write, current_dir: &Path) -> std::io::Result<()
     Ok(())
 }
 
-// Build a `git` Command insulated from the parent process's environment and
-// configuration so that the recorded revision depends only on the repository
-// being built, not on the machine or user running the build.
+// Build a `git` Command that ignores ambient path-redirecting GIT_* env vars,
+// so that the recorded revision is always for the repository at current_dir
+// and not whatever an outer process (e.g. `git rebase --exec cargo ...`) has
+// pointed git at. Mirrors the sanitization cargo applies in fetch_with_cli.
 fn git(current_dir: &Path) -> Command {
     let mut cmd = Command::new("git");
     cmd.current_dir(current_dir);
-    // Remove all ambient GIT_* env vars so they cannot influence git's
-    // behaviour - notably GIT_DIR, GIT_WORK_TREE, and GIT_INDEX_FILE, which
-    // would redirect git to a different repository. Other (non-GIT_) env
-    // vars are inherited so the command can still use environment variables
-    // like PATH, or SystemRoot on Windows.
-    for (k, _) in std::env::vars_os() {
-        if k.to_string_lossy().starts_with("GIT_") {
-            cmd.env_remove(&k);
-        }
-    }
-    // GIT_CONFIG_NOSYSTEM=1 tells git not to read the system-wide config
-    // (e.g. /etc/gitconfig), so machine-level git settings cannot change
-    // the revision output.
-    cmd.env("GIT_CONFIG_NOSYSTEM", "1");
-    // GIT_CONFIG_GLOBAL pointed at /dev/null tells git not to read the
-    // user's global config (~/.gitconfig and $XDG_CONFIG_HOME/git/config).
-    // On Windows /dev/null does not exist, which git silently treats as an
-    // empty config - the same effect. Combined with NOSYSTEM, this leaves
-    // only the repository's local config in effect. Requires git 2.32+;
-    // older git ignores it and still reads the user's global config.
-    cmd.env("GIT_CONFIG_GLOBAL", "/dev/null");
-    // GIT_TERMINAL_PROMPT=0 tells git never to prompt at the terminal. In
-    // non-interactive environments like CI a prompt would hang the build
-    // indefinitely; this turns the prompt into an immediate error instead.
+    cmd.env_remove("GIT_DIR");
+    cmd.env_remove("GIT_WORK_TREE");
+    cmd.env_remove("GIT_INDEX_FILE");
+    cmd.env_remove("GIT_OBJECT_DIRECTORY");
+    cmd.env_remove("GIT_ALTERNATE_OBJECT_DIRECTORIES");
+    // Disable terminal prompts so a misconfigured credential or hook can't
+    // hang a non-interactive build (e.g. CI) indefinitely.
     cmd.env("GIT_TERMINAL_PROMPT", "0");
     cmd
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,8 +82,7 @@ fn __init(w: &mut impl std::io::Write, current_dir: &Path) -> std::io::Result<()
     // Read the git revision from the git repository containing the code being
     // built.
     if git_sha.is_none() {
-        match Command::new("git")
-            .current_dir(current_dir)
+        match git(current_dir)
             .arg("rev-parse")
             .arg("--git-dir")
             .output()
@@ -114,8 +113,7 @@ fn __init(w: &mut impl std::io::Write, current_dir: &Path) -> std::io::Result<()
                 writeln!(w, "cargo:rerun-if-changed={git_dir}/HEAD")?;
                 writeln!(w, "cargo:rerun-if-changed={git_dir}/refs")?;
 
-                match Command::new("git")
-                    .current_dir(current_dir)
+                match git(current_dir)
                     .arg("rev-parse")
                     .arg("HEAD")
                     .output()
@@ -132,8 +130,7 @@ fn __init(w: &mut impl std::io::Write, current_dir: &Path) -> std::io::Result<()
                             .ok()
                             .map(|s| s.trim().to_string());
                         if let Some(sha) = sha.filter(|s| !s.is_empty()) {
-                            let dirty = match Command::new("git")
-                                .current_dir(current_dir)
+                            let dirty = match git(current_dir)
                                 .arg("status")
                                 .arg("--porcelain")
                                 .arg("--untracked-files=normal")
@@ -162,6 +159,40 @@ fn __init(w: &mut impl std::io::Write, current_dir: &Path) -> std::io::Result<()
     }
 
     Ok(())
+}
+
+// Build a `git` Command insulated from the parent process's environment and
+// configuration so that the recorded revision depends only on the repository
+// being built, not on the machine or user running the build.
+fn git(current_dir: &Path) -> Command {
+    let mut cmd = Command::new("git");
+    cmd.current_dir(current_dir);
+    // Remove all ambient GIT_* env vars so they cannot influence git's
+    // behaviour - notably GIT_DIR, GIT_WORK_TREE, and GIT_INDEX_FILE, which
+    // would redirect git to a different repository. Other (non-GIT_) env
+    // vars are inherited so the command can still use environment variables
+    // like PATH, or SystemRoot on Windows.
+    for (k, _) in std::env::vars_os() {
+        if k.to_string_lossy().starts_with("GIT_") {
+            cmd.env_remove(&k);
+        }
+    }
+    // GIT_CONFIG_NOSYSTEM=1 tells git not to read the system-wide config
+    // (e.g. /etc/gitconfig), so machine-level git settings cannot change
+    // the revision output.
+    cmd.env("GIT_CONFIG_NOSYSTEM", "1");
+    // GIT_CONFIG_GLOBAL pointed at /dev/null tells git not to read the
+    // user's global config (~/.gitconfig and $XDG_CONFIG_HOME/git/config).
+    // On Windows /dev/null does not exist, which git silently treats as an
+    // empty config - the same effect. Combined with NOSYSTEM, this leaves
+    // only the repository's local config in effect. Requires git 2.32+;
+    // older git ignores it and still reads the user's global config.
+    cmd.env("GIT_CONFIG_GLOBAL", "/dev/null");
+    // GIT_TERMINAL_PROMPT=0 tells git never to prompt at the terminal. In
+    // non-interactive environments like CI a prompt would hang the build
+    // indefinitely; this turns the prompt into an immediate error instead.
+    cmd.env("GIT_TERMINAL_PROMPT", "0");
+    cmd
 }
 
 #[derive(serde_derive::Serialize, serde_derive::Deserialize, Default)]

--- a/src/test.rs
+++ b/src/test.rs
@@ -244,6 +244,51 @@ fn test_published_empty_sha() {
     assert_eq!(out, expected);
 }
 
+// Verifies that ambient GIT_* env vars in the parent process do not
+// influence __init. Done by re-invoking the test binary as a subprocess
+// with adversarial env vars set on the child, so the env modifications
+// never touch the parent test process and cannot race with parallel tests.
+#[test]
+fn test_ambient_git_env_vars_are_ignored() {
+    const CHILD_REPO_ENV: &str = "CRATE_GIT_REVISION_TEST_CHILD_REPO";
+
+    if let Ok(git_dir) = std::env::var(CHILD_REPO_ENV) {
+        let mut out = Vec::new();
+        super::__init(&mut out, Path::new(&git_dir)).unwrap();
+        let out = str::from_utf8(&out).unwrap();
+        let expected = "cargo:rerun-if-changed=.git/index
+cargo:rerun-if-changed=.git/HEAD
+cargo:rerun-if-changed=.git/refs
+cargo:rustc-env=GIT_REVISION=[0-9a-f]{40}\n";
+        assert!(
+            Regex::new(expected).unwrap().is_match(out),
+            "child __init output did not match: {out}"
+        );
+        return;
+    }
+
+    let tempdir = tempfile::tempdir().unwrap();
+    let git_dir = tempdir.path();
+    init_git_repo(git_dir);
+
+    let output = Command::new(std::env::current_exe().unwrap())
+        .arg("--exact")
+        .arg("--nocapture")
+        .arg("test::test_ambient_git_env_vars_are_ignored")
+        .env(CHILD_REPO_ENV, git_dir)
+        .env("GIT_DIR", "/nonexistent")
+        .env("GIT_WORK_TREE", "/nonexistent")
+        .env("GIT_INDEX_FILE", "/nonexistent")
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "child process failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
 #[test]
 fn test_published_trailing_whitespace() {
     let tempdir = tempfile::tempdir().unwrap();

--- a/src/test.rs
+++ b/src/test.rs
@@ -252,7 +252,7 @@ fn test_published_empty_sha() {
 fn test_ambient_git_env_vars_are_ignored() {
     const CHILD_REPO_ENV: &str = "CRATE_GIT_REVISION_TEST_CHILD_REPO";
 
-    if let Ok(git_dir) = std::env::var(CHILD_REPO_ENV) {
+    if let Some(git_dir) = std::env::var_os(CHILD_REPO_ENV) {
         let mut out = Vec::new();
         super::__init(&mut out, Path::new(&git_dir)).unwrap();
         let out = str::from_utf8(&out).unwrap();


### PR DESCRIPTION
### What
Add a private `git()` helper that builds a `git` Command insulated from the parent process and route the three internal invocations (`rev-parse --git-dir`, `rev-parse HEAD`, `status --porcelain`) through it. The helper:

- Removes every ambient `GIT_*` env var from the child (notably `GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`, `GIT_ASKPASS`).
- Sets `GIT_CONFIG_NOSYSTEM=1` to skip system config (`/etc/gitconfig`).
- Sets `GIT_CONFIG_GLOBAL=/dev/null` to skip user config (`~/.gitconfig`, `$XDG_CONFIG_HOME/git/config`). On Windows the path is nonexistent, which git silently treats as empty - the same effect. Requires git 2.32+; older git ignores it and falls back to the user's global config.
- Sets `GIT_TERMINAL_PROMPT=0` so git never prompts at the terminal.

Non-`GIT_*` env vars (`PATH`, `SystemRoot`, locale, etc.) are inherited so unusual build environments keep working.

Adds `test_ambient_git_env_vars_are_ignored` that re-invokes the test binary as a subprocess with `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE` pointed at `/nonexistent`. The env modifications never touch the parent test process, so the test does not race with the other tests' git invocations.

### Why
Ambient `GIT_*` env vars in the build environment can change the recorded revision or cause the build to hang:

- `GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE` would redirect `git rev-parse` and `git status` to a different repository, producing a `GIT_REVISION` that does not match the crate being built.
- Without `GIT_TERMINAL_PROMPT=0`, git can prompt for credentials and hang a CI build indefinitely.
- System and user git config (`/etc/gitconfig`, `~/.gitconfig`) can configure helpers, rewrite URLs, or change status semantics (e.g. `core.fileMode`, `core.autocrlf`), making the recorded revision depend on the machine and user running the build.

After this change the recorded revision depends only on the repository being built.