### PR TITLE
Ignore untracked files (reverting part of #26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ For example, for a clean worktree:
 1a2b3c4d5e6f7890abcdef1234567890abcdef12
 ```
 
-For example, suffixed with `-dirty` when a worktree contains changes or
-untracked files:
+For example, suffixed with `-dirty` when a worktree contains changes:
 
 ```text
 1a2b3c4d5e6f7890abcdef1234567890abcdef12-dirty

--- a/README.md
+++ b/README.md
@@ -31,6 +31,29 @@ state changes. Crates that vendor submodules may produce `-dirty` builds
 where they did not previously when the submodule's working tree differs
 from its recorded commit.
 
+### Untracked files are not considered dirty
+
+Only changes to tracked files mark the revision as `-dirty`. Untracked
+files in the worktree are intentionally ignored (`git status` is invoked
+with `--untracked-files=no`).
+
+Detecting untracked files reliably from a build script would require
+telling Cargo to re-run `build.rs` whenever any file appears anywhere in
+the crate directory (e.g. `cargo:rerun-if-changed=.`). That makes the
+build script — and everything that depends on it — re-run on essentially
+every filesystem change in the tree, including editor swap files and
+unrelated edits. The cost on every incremental build outweighs the
+marginal correctness gain, especially since untracked files do not
+typically affect a Rust build: source files are pulled into a crate
+explicitly via `mod` declarations and `#[path]` attributes, not by
+scanning the filesystem.
+
+Without watching the whole tree, the dirty signal for untracked files
+would be inconsistent: a cached build would report clean even after an
+untracked file appeared, and only `cargo clean` followed by a fresh
+build would surface it. To avoid that inconsistency, untracked files
+are not part of the dirty check at all.
+
 Requires the use of a build.rs build script. See [Build Scripts]() for more
 details on how Rust build scripts work.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,29 @@
 //! `-dirty` builds where they did not previously when the submodule's
 //! working tree differs from its recorded commit.
 //!
+//! ### Untracked files are not considered dirty
+//!
+//! Only changes to tracked files mark the revision as `-dirty`. Untracked
+//! files in the worktree are intentionally ignored (`git status` is invoked
+//! with `--untracked-files=no`).
+//!
+//! Detecting untracked files reliably from a build script would require
+//! telling Cargo to re-run `build.rs` whenever any file appears anywhere in
+//! the crate directory (e.g. `cargo:rerun-if-changed=.`). That makes the
+//! build script — and everything that depends on it — re-run on essentially
+//! every filesystem change in the tree, including editor swap files and
+//! unrelated edits. The cost on every incremental build outweighs the
+//! marginal correctness gain, especially since untracked files do not
+//! typically affect a Rust build: source files are pulled into a crate
+//! explicitly via `mod` declarations and `#[path]` attributes, not by
+//! scanning the filesystem.
+//!
+//! Without watching the whole tree, the dirty signal for untracked files
+//! would be inconsistent: a cached build would report clean even after an
+//! untracked file appeared, and only `cargo clean` followed by a fresh
+//! build would surface it. To avoid that inconsistency, untracked files
+//! are not part of the dirty check at all.
+//!
 //! Requires the use of a build.rs build script. See [Build Scripts]() for more
 //! details on how Rust build scripts work.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,7 @@
 //! 1a2b3c4d5e6f7890abcdef1234567890abcdef12
 //! ```
 //!
-//! For example, suffixed with `-dirty` when a worktree contains changes or
-//! untracked files:
+//! For example, suffixed with `-dirty` when a worktree contains changes:
 //!
 //! ```text
 //! 1a2b3c4d5e6f7890abcdef1234567890abcdef12-dirty
@@ -136,7 +135,7 @@ fn __init(w: &mut impl std::io::Write, current_dir: &Path) -> std::io::Result<()
                                 .current_dir(current_dir)
                                 .arg("status")
                                 .arg("--porcelain")
-                                .arg("--untracked-files=normal")
+                                .arg("--untracked-files=no")
                                 .output()
                                 .map(|o| o.stdout)
                             {

--- a/src/test.rs
+++ b/src/test.rs
@@ -129,7 +129,7 @@ cargo:rustc-env=GIT_REVISION=[0-9a-f]{40}-dirty\n";
 }
 
 #[test]
-fn test_dirty_untracked() {
+fn test_untracked_is_not_dirty() {
     let tempdir = tempfile::tempdir().unwrap();
     let git_dir = tempdir.path();
 
@@ -145,10 +145,11 @@ fn test_dirty_untracked() {
     let expected = "cargo:rerun-if-changed=.git/index
 cargo:rerun-if-changed=.git/HEAD
 cargo:rerun-if-changed=.git/refs
-cargo:rustc-env=GIT_REVISION=[0-9a-f]{40}-dirty\n";
+cargo:rustc-env=GIT_REVISION=[0-9a-f]{40}\n";
     println!("{out}");
     println!("{expected}");
     assert!(Regex::new(expected).unwrap().is_match(out));
+    assert!(!out.contains("-dirty"));
 }
 
 #[test]


### PR DESCRIPTION
### What

Reverts the behavior introduced in #26 that marked the `GIT_REVISION` as `-dirty` when the worktree contained untracked files. The git status check now passes `--untracked-files=no` so only tracked, modified files contribute to the dirty suffix.

The `test_dirty_untracked` test is replaced with `test_untracked_is_not_dirty`, which asserts the opposite: that an untracked file in the worktree does not produce a `-dirty` revision.

#26's switch from `git describe --always --exclude=* --long --abbrev=1000 --dirty` to `git rev-parse HEAD` + `git status --porcelain` is **retained**. Splitting revision lookup from dirty detection is clearer than overloading `git describe` with `--dirty` and a pile of flags whose only purpose was to suppress describe's tag/abbreviation behavior so it returned a bare SHA. Each command now does one thing: `rev-parse` gets the SHA, `status --porcelain` reports worktree state.

### Why

Two reasons:

1. We cannot efficiently detect untracked files from a build script.

   Cargo's rerun mechanism is path-based: `cargo:rerun-if-changed=<path>` only works for paths we can name ahead of time. Untracked files are, by definition, unknown to git — and therefore unknown to us — at the time the build script runs, so we cannot list them individually.

   The only way to catch new untracked files appearing in the worktree is to watch the crate directory itself (`cargo:rerun-if-changed=.` or similar). That works, but it forces `build.rs` to re-run on essentially every change anywhere in the tree — editor swap files, doc edits, test fixtures, anything — invalidating the build script and dependent compilation far more often than the revision actually changes. The cost is paid on every developer's incremental build, for a marginal correctness improvement.

   Without that, the dirty signal is inconsistent:

   - Build with no untracked files → emits clean revision → result is cached.
   - Add an untracked file → nothing invalidates the cache → next build still reports clean.
   - `cargo clean` → fresh build picks up the untracked file → now reports dirty.

   Whether the same worktree produces `-dirty` depends on whether the build was cached.

2. Untracked files don't routinely affect Rust builds.

   Rust source files are included in a crate explicitly — via `mod` declarations and `#[path]` attributes — not implicitly by scanning the filesystem. An untracked `.rs` file sitting in `src/` is not compiled into the crate unless something already in the module tree references it. In the common case it has no effect on the build output, so marking the revision `-dirty` for its presence is misleading: the produced binary is byte-for-byte identical to a clean build.
