### PR TITLE
Warn when GIT_REVISION is not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,22 +16,22 @@ dirty.
 
 For example, for a clean worktree:
 
-```text
+```
 1a2b3c4d5e6f7890abcdef1234567890abcdef12
 ```
 
 For example, suffixed with `-dirty` when a worktree contains changes:
 
-```text
+```
 1a2b3c4d5e6f7890abcdef1234567890abcdef12-dirty
 ```
 
-The dirty check uses `git status --porcelain`, which also reports submodule
-state changes. Crates that vendor submodules may produce `-dirty` builds
-where they did not previously when the submodule's working tree differs
-from its recorded commit.
+The dirty check uses `git status --porcelain`, which also reports
+submodule state changes. Crates that vendor submodules may produce
+`-dirty` builds where they did not previously when the submodule's
+working tree differs from its recorded commit.
 
-### Untracked files are not considered dirty
+#### Untracked files are not considered dirty
 
 Only changes to tracked files mark the revision as `-dirty`. Untracked
 files in the worktree are intentionally ignored (`git status` is invoked
@@ -77,7 +77,29 @@ crate_git_revision::init();
 Add the following to the crate's `lib.rs` or `main.rs` file:
 
 ```rust
-pub const GIT_REVISION: &str = env!("GIT_REVISION");
+pub const GIT_REVISION: Option<&str> = option_env!("GIT_REVISION");
 ```
+
+#### Use `option_env!`, not `env!`
+
+Downstream code **should** read `GIT_REVISION` with [`option_env!`] so
+the application can decide for itself what to do when the revision is
+absent.
+
+The build script intentionally does not set `GIT_REVISION` when the
+revision cannot be derived (no git binary, not in a git checkout, no
+`.cargo_vcs_info.json`, sandbox or permission failures, etc.), and does
+not substitute any value in its place. Only the application knows
+whether a missing revision is acceptable and what should happen in that
+case — this crate stays out of that decision on purpose.
+
+Using [`env!`] when the revision is absent produces a hard compile failure
+with no helpful diagnostic, which breaks vendored builds, source tarballs,
+and restricted build environments. Reserve [`env!("GIT_REVISION")`][`env!`]
+for cases where the revision is genuinely critical and the build *must* fail
+without it (e.g. a release artifact whose provenance is non-negotiable).
+
+When the revision cannot be derived, the build script emits a
+`cargo:warning` so the missing value is visible in build output.
 
 License: Apache-2.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,8 +75,30 @@
 //! Add the following to the crate's `lib.rs` or `main.rs` file:
 //!
 //! ```ignore
-//! pub const GIT_REVISION: &str = env!("GIT_REVISION");
+//! pub const GIT_REVISION: Option<&str> = option_env!("GIT_REVISION");
 //! ```
+//!
+//! ### Use `option_env!`, not `env!`
+//!
+//! Downstream code **should** read `GIT_REVISION` with [`option_env!`] so
+//! the application can decide for itself what to do when the revision is
+//! absent.
+//!
+//! The build script intentionally does not set `GIT_REVISION` when the
+//! revision cannot be derived (no git binary, not in a git checkout, no
+//! `.cargo_vcs_info.json`, sandbox or permission failures, etc.), and does
+//! not substitute any value in its place. Only the application knows
+//! whether a missing revision is acceptable and what should happen in that
+//! case — this crate stays out of that decision on purpose.
+//!
+//! Using [`env!`] when the revision is absent produces a hard compile failure
+//! with no helpful diagnostic, which breaks vendored builds, source tarballs,
+//! and restricted build environments. Reserve [`env!("GIT_REVISION")`][`env!`]
+//! for cases where the revision is genuinely critical and the build *must* fail
+//! without it (e.g. a release artifact whose provenance is non-negotiable).
+//!
+//! When the revision cannot be derived, the build script emits a
+//! `cargo:warning` so the missing value is visible in build output.
 
 use std::{fs::read_to_string, path::Path, process::Command, str};
 
@@ -185,6 +207,8 @@ fn __init(w: &mut impl std::io::Write, current_dir: &Path) -> std::io::Result<()
 
     if let Some(git_sha) = git_sha.filter(|s| !s.is_empty()) {
         writeln!(w, "cargo:rustc-env=GIT_REVISION={git_sha}")?;
+    } else {
+        writeln!(w, "cargo:warning=GIT_REVISION not set")?;
     }
 
     Ok(())

--- a/src/test.rs
+++ b/src/test.rs
@@ -264,10 +264,28 @@ fn test_published_empty_sha() {
     let res = super::__init(&mut out, crate_dir);
     assert!(res.is_ok());
     let out = str::from_utf8(&out).unwrap();
-    let expected = "";
+    let expected = "cargo:warning=GIT_REVISION not set\n";
     println!("{out}");
     println!("{expected}");
-    assert_eq!(out, expected);
+    assert!(Regex::new(expected).unwrap().is_match(out));
+    assert!(!out.contains("cargo:rustc-env=GIT_REVISION="));
+}
+
+#[test]
+fn test_warns_when_revision_cannot_be_derived() {
+    // A directory that is neither a git checkout nor a published crate
+    // (no .cargo_vcs_info.json) should not set GIT_REVISION and should
+    // emit a cargo:warning so the missing value is visible.
+    let tempdir = tempfile::tempdir().unwrap();
+    let crate_dir = tempdir.path();
+
+    let mut out = Vec::new();
+    let res = super::__init(&mut out, crate_dir);
+    assert!(res.is_ok());
+    let out = str::from_utf8(&out).unwrap();
+    println!("{out}");
+    assert!(out.contains("cargo:warning=GIT_REVISION not set"));
+    assert!(!out.contains("cargo:rustc-env=GIT_REVISION="));
 }
 
 // Verifies that ambient GIT_* env vars in the parent process do not


### PR DESCRIPTION
### What
- Emit a `cargo:warning=GIT_REVISION not set` from the build script whenever the revision cannot be derived (no `.cargo_vcs_info.json`, not a git checkout, missing git binary, unreadable output, etc.) so the missing value is visible in build output rather than failing silently downstream.
- Document in `src/lib.rs` and `README.md` that downstream code should consume `GIT_REVISION` with `option_env!` so the application decides what to do when the revision is absent. `env!` is reserved for cases where the revision is genuinely critical and the build *must* fail without it.
- Update the example snippet from `env!("GIT_REVISION")` to `option_env!("GIT_REVISION")`.
- Update `test_published_empty_sha` to expect the new warning and add `test_warns_when_revision_cannot_be_derived` covering the no-git, no-vcs-info path.

### Why
`__init()` only set `GIT_REVISION` when a revision was successfully obtained, and any error inside `__init` was discarded by the public `init()` wrapper. In common failure conditions — non-git checkouts, sandboxes without `git`, restricted CI environments, invalid UTF-8, parse errors — the build script emitted no `cargo:rustc-env=GIT_REVISION=...` line at all, and crates using `env!("GIT_REVISION")` failed to compile with no helpful diagnostic.

The library deliberately does not substitute a default value (such as `"unknown"`) when the revision can't be derived: only the application layer knows whether a missing revision is acceptable, so the crate stays out of that decision. Combining the explicit `cargo:warning` with strong `option_env!` guidance gives downstream crates the signal they need without taking the choice away from them.