### PR TITLE
Replace current_dir().unwrap() in init() with env::var_os("CARGO_MANIFEST_DIR")

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,9 +84,14 @@ use std::{fs::read_to_string, path::Path, process::Command, str};
 /// the current crate.
 ///
 /// Intended to be called from within a build script, `build.rs` file, for the
-/// crate.
+/// crate. Requires the current directory to be the directory containing the
+/// build script, as is the case when cargo executes the build script.
 pub fn init() {
-    let _res = __init(&mut std::io::stdout(), &std::env::current_dir().unwrap());
+    // Cargo guarantees the current directory is the build script's package
+    // manifest directory when build.rs is invoked.
+    // https://doc.rust-lang.org/cargo/reference/build-scripts.html#inputs-to-the-build-script
+    let current_dir = std::env::current_dir().expect("getting current directory");
+    let _res = __init(&mut std::io::stdout(), &current_dir);
 }
 
 fn __init(w: &mut impl std::io::Write, current_dir: &Path) -> std::io::Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,14 +84,16 @@ use std::{fs::read_to_string, path::Path, process::Command, str};
 /// the current crate.
 ///
 /// Intended to be called from within a build script, `build.rs` file, for the
-/// crate. Requires the current directory to be the directory containing the
-/// build script, as is the case when cargo executes the build script.
+/// crate. Uses `CARGO_MANIFEST_DIR` to locate the crate, which is set by Cargo
+/// when executing the build script.
 pub fn init() {
-    // Cargo guarantees the current directory is the build script's package
-    // manifest directory when build.rs is invoked.
-    // https://doc.rust-lang.org/cargo/reference/build-scripts.html#inputs-to-the-build-script
-    let current_dir = std::env::current_dir().expect("getting current directory");
-    let _res = __init(&mut std::io::stdout(), &current_dir);
+    // Use CARGO_MANIFEST_DIR rather than the current directory so the crate
+    // path is correct even when `package.build` points to a build script
+    // outside the package source tree.
+    // https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts
+    let manifest_dir = std::env::var_os("CARGO_MANIFEST_DIR")
+        .expect("CARGO_MANIFEST_DIR is set by cargo when executing build scripts");
+    let _res = __init(&mut std::io::stdout(), Path::new(&manifest_dir));
 }
 
 fn __init(w: &mut impl std::io::Write, current_dir: &Path) -> std::io::Result<()> {


### PR DESCRIPTION
### What
Replace `current_dir().unwrap()` in `init()` with `env::var_os("CARGO_MANIFEST_DIR")`, and document why this is the correct source of the crate path in a build script.

### Why
`current_dir()` happens to equal the manifest directory in the common case, but `package.build` in `Cargo.toml` can point to a build script located outside the package source tree. `CARGO_MANIFEST_DIR` is the env var Cargo explicitly sets to the package's manifest directory when executing the build script, so it's the correct source for the crate path regardless of where the build script lives.

Using `expect` instead of `unwrap` also surfaces a clear message at the panic site. Under normal operations there is no reason for `CARGO_MANIFEST_DIR` to be unset — Cargo always sets it for build scripts. If it is unset, the build system is already broken in other, larger, disastrous ways, and graceful handling here would not meaningfully recover the build.

Some discussion:
- https://stellarfoundation.slack.com/archives/C09UBQTVBV2/p1779770578107319