### PR TITLE
Document reproducibility and use of git

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,22 +16,22 @@ dirty.
 
 For example, for a clean worktree:
 
-```text
+```
 1a2b3c4d5e6f7890abcdef1234567890abcdef12
 ```
 
 For example, suffixed with `-dirty` when a worktree contains changes:
 
-```text
+```
 1a2b3c4d5e6f7890abcdef1234567890abcdef12-dirty
 ```
 
-The dirty check uses `git status --porcelain`, which also reports submodule
-state changes. Crates that vendor submodules may produce `-dirty` builds
-where they did not previously when the submodule's working tree differs
-from its recorded commit.
+The dirty check uses `git status --porcelain`, which also reports
+submodule state changes. Crates that vendor submodules may produce
+`-dirty` builds where they did not previously when the submodule's
+working tree differs from its recorded commit.
 
-### Untracked files are not considered dirty
+#### Untracked files are not considered dirty
 
 Only changes to tracked files mark the revision as `-dirty`. Untracked
 files in the worktree are intentionally ignored (`git status` is invoked
@@ -53,6 +53,32 @@ would be inconsistent: a cached build would report clean even after an
 untracked file appeared, and only `cargo clean` followed by a fresh
 build would surface it. To avoid that inconsistency, untracked files
 are not part of the dirty check at all.
+
+#### Builds without version info
+
+When neither `.cargo_vcs_info.json` nor a working `git` is available —
+e.g. building from a source tarball that is not a published crate, or
+in an environment without the `git` binary — `GIT_REVISION` is left
+unset rather than substituted with a placeholder.
+
+#### Git use
+
+Shallow clones are fine — only `HEAD` is inspected, so a depth of 1 is
+sufficient.
+
+For reproducible builds, ensure the working tree is clean at the
+moment the build script runs. Build steps that modify tracked files
+beforehand (in-place version bumps, code generators that overwrite
+checked-in files) will produce a `-dirty` revision. Building from the
+published crate avoids this by taking the `.cargo_vcs_info.json` path.
+
+Path-redirecting `GIT_*` environment variables (`GIT_DIR`,
+`GIT_WORK_TREE`, etc.) are stripped from the `git` invocations so a CI
+runner that sets them for an outer repository does not leak into the
+recorded revision. `GIT_TERMINAL_PROMPT=0` is set so misconfigured
+credentials cannot hang a non-interactive build.
+
+#### Build scripts
 
 Requires the use of a build.rs build script. See [Build Scripts]() for more
 details on how Rust build scripts work.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ credentials cannot hang a non-interactive build.
 
 #### Build scripts
 
-Requires the use of a build.rs build script. See [Build Scripts]() for more
+Requires the use of a build.rs build script. See [Build Scripts] for more
 details on how Rust build scripts work.
 
 [Build Scripts]: https://doc.rust-lang.org/cargo/reference/build-scripts.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,32 @@
 //! build would surface it. To avoid that inconsistency, untracked files
 //! are not part of the dirty check at all.
 //!
+//! ### Builds without version info
+//!
+//! When neither `.cargo_vcs_info.json` nor a working `git` is available —
+//! e.g. building from a source tarball that is not a published crate, or
+//! in an environment without the `git` binary — `GIT_REVISION` is left
+//! unset rather than substituted with a placeholder.
+//!
+//! ### Git use
+//!
+//! Shallow clones are fine — only `HEAD` is inspected, so a depth of 1 is
+//! sufficient.
+//!
+//! For reproducible builds, ensure the working tree is clean at the
+//! moment the build script runs. Build steps that modify tracked files
+//! beforehand (in-place version bumps, code generators that overwrite
+//! checked-in files) will produce a `-dirty` revision. Building from the
+//! published crate avoids this by taking the `.cargo_vcs_info.json` path.
+//!
+//! Path-redirecting `GIT_*` environment variables (`GIT_DIR`,
+//! `GIT_WORK_TREE`, etc.) are stripped from the `git` invocations so a CI
+//! runner that sets them for an outer repository does not leak into the
+//! recorded revision. `GIT_TERMINAL_PROMPT=0` is set so misconfigured
+//! credentials cannot hang a non-interactive build.
+//!
+//! ### Build scripts
+//!
 //! Requires the use of a build.rs build script. See [Build Scripts]() for more
 //! details on how Rust build scripts work.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@
 //!
 //! ### Build scripts
 //!
-//! Requires the use of a build.rs build script. See [Build Scripts]() for more
+//! Requires the use of a build.rs build script. See [Build Scripts] for more
 //! details on how Rust build scripts work.
 //!
 //! [Build Scripts]: https://doc.rust-lang.org/cargo/reference/build-scripts.html


### PR DESCRIPTION
### What
Expand the crate-level docs with sections covering builds without version info, shallow clone support, reproducible-build expectations around clean working trees, the stripping of path-redirecting `GIT_*` env vars, and the `GIT_TERMINAL_PROMPT=0` behavior.

### Why
Surface behaviors that previously required reading the source: when `GIT_REVISION` stays unset, why CI environments setting `GIT_DIR`/`GIT_WORK_TREE` no longer leak into recorded revisions, and how in-place build steps can produce a spurious `-dirty` suffix.