### PR TITLE
Check readme stays in sync with source docs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ jobs:
 
   complete:
     if: always()
-    needs: [fmt, build-and-test, docs, publish-dry-run]
+    needs: [fmt, build-and-test, docs, readme, publish-dry-run]
     runs-on: ubuntu-latest
     steps:
     - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
@@ -53,6 +53,15 @@ jobs:
     - uses: stellar/actions/rust-cache@main
     - run: rustup update
     - run: cargo doc
+
+  readme:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: stellar/actions/rust-cache@main
+    - run: rustup install nightly
+    - run: make readme
+    - run: git add -N . && git diff HEAD --exit-code
 
   publish-dry-run:
     if: startsWith(github.head_ref, 'release/')

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,8 @@ fmt:
 	cargo fmt --all
 
 readme:
-	cargo readme > README.md
+	cargo +nightly rustdoc -- -Zunstable-options -wjson
+	jq -r '.index[.root|tostring].docs' target/doc/crate_git_revision.json > README.md
 
 clean:
 	cargo clean

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# crate-git-revision
-
 Embed the git revision of a crate in its build.
 
 Supports embedding the version from a local or remote git repository the build
@@ -26,10 +24,10 @@ For example, suffixed with `-dirty` when a worktree contains changes:
 1a2b3c4d5e6f7890abcdef1234567890abcdef12-dirty
 ```
 
-The dirty check uses `git status --porcelain`, which also reports submodule
-state changes. Crates that vendor submodules may produce `-dirty` builds
-where they did not previously when the submodule's working tree differs
-from its recorded commit.
+The dirty check uses `git status --porcelain`, which also reports
+submodule state changes. Crates that vendor submodules may produce
+`-dirty` builds where they did not previously when the submodule's
+working tree differs from its recorded commit.
 
 ### Untracked files are not considered dirty
 
@@ -59,7 +57,7 @@ details on how Rust build scripts work.
 
 [Build Scripts]: https://doc.rust-lang.org/cargo/reference/build-scripts.html
 
-#### Examples
+### Examples
 
 Add the following to the crate's `Cargo.toml` file:
 
@@ -76,8 +74,6 @@ crate_git_revision::init();
 
 Add the following to the crate's `lib.rs` or `main.rs` file:
 
-```rust
+```ignore
 pub const GIT_REVISION: &str = env!("GIT_REVISION");
 ```
-
-License: Apache-2.0


### PR DESCRIPTION
### What

Add a CI job that regenerates README.md from the crate's doc comments and fails if it differs from what's committed. Uses the same `cargo +nightly rustdoc -Zunstable-options -wjson` plus jq approach already in use in stellar/rs-soroban-sdk, replacing the previous cargo-readme dependency.

### Why

Mirror the readme-check pattern from stellar/rs-soroban-sdk so this crate catches stale READMEs in CI the same way.